### PR TITLE
Fix refs on intrinisic elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create tailwind css react components like styled components with classes name on
 ```js
 const Button = tw.div`
     ${(p) => (p.$primary ? "bg-indigo-600" : "bg-indigo-300")}
-    
+
     flex
     inline-flex
     items-center
@@ -31,7 +31,7 @@ const Button = tw.div`
     rounded
     shadow-sm
     text-white
-    
+
     hover:bg-indigo-700
     focus:outline-none
 `
@@ -175,9 +175,9 @@ Will be rendered as
 
 **Be sure to set the entire class name**
 
-✅ &nbsp;Do `${p => p.primary ? "bg-indigo-600" : "bg-indigo-300"}`
+✅ &nbsp;Do `${p => p.$primary ? "bg-indigo-600" : "bg-indigo-300"}`
 
-❌ &nbsp;Don't `bg-indigo-${p => p.primary ? "600" : "300"}`
+❌ &nbsp;Don't `bg-indigo-${p => p.$primary ? "600" : "300"}`
 
 ---
 

--- a/src/__tests__/tailwind.test.tsx
+++ b/src/__tests__/tailwind.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import tw from '../tailwind'
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 interface TestCompProps {
   className?: string
@@ -10,6 +10,24 @@ interface TestCompProps {
 }
 
 describe('tw', () => {
+  it('passes ref [Type Test]', async () => {
+    const Div = tw.div`bg-gray-400`;
+    let r: any = undefined;
+    const HasRef = () => {
+      const ref = useRef<HTMLDivElement>();
+      useEffect(() => {
+        r = ref;
+      }, [ref]);
+      return <Div data-testid="mydiv" ref={ref}>ref</Div>
+    }
+    render(<HasRef />);
+    await act(async () => {
+      expect(r).not.toBeUndefined();
+      expect(r.current).not.toBeUndefined();
+      expect(r.current.localName).toBe('div');
+    });
+  })
+
   it('matches snapshot with intrinsic element', () => {
     const Div = tw.div`bg-gray-400`;
     const { asFragment } = render(<Div>test</Div>);

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -65,9 +65,9 @@ export type IntrinsicElements = {
 }
 
 const intrinsicElements: IntrinsicElements = domElements.reduce(
-    (acc, DomElement) => ({
+    <K extends keyof JSX.IntrinsicElements>(acc: IntrinsicElements, DomElement: K) => ({
         ...acc,
-        [DomElement]: functionTemplate((p) => <DomElement {...p} />)
+        [DomElement]: functionTemplate(DomElement as unknown as React.ComponentType<JSX.IntrinsicElements[K]>)
     }),
     {} as IntrinsicElements
 )

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -61,7 +61,7 @@ function functionTemplate<P extends ClassNameProp, E = any>(Element: React.Compo
 }
 
 export type IntrinsicElements = {
-    [key in keyof JSX.IntrinsicElements]: FunctionTemplate<JSX.IntrinsicElements[key], key>
+    [key in keyof JSX.IntrinsicElements]: FunctionTemplate<JSX.IntrinsicElements[key], any>
 }
 
 const intrinsicElements: IntrinsicElements = domElements.reduce(


### PR DESCRIPTION
So, my last PR broke passing refs to intrinsic elements because I had `(p) => <DomElement {...p> />`, which makes this a functional component, and thus React won't forward refs (annoyingly). Additionally, I had messed up the types for the element for forward ref, which was causing type errors.

This fixes both of those issues, and adds a test to verify that it's not broken.

Sorry about that regression. 😓 