### PR TITLE
Fixes issue with multiple template literal expressions.

### DIFF
--- a/src/__tests__/__snapshots__/tailwind.test.tsx.snap
+++ b/src/__tests__/__snapshots__/tailwind.test.tsx.snap
@@ -29,3 +29,23 @@ exports[`tw matches snapshot with intrinsic element 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`tw matches snapshot with two dynamic properties 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-gray-500 p-10"
+  >
+    test
+  </div>
+</DocumentFragment>
+`;
+
+exports[`tw matches snapshot with two properties 1`] = `
+<DocumentFragment>
+  <div
+    class="bg-gray-500 p-10"
+  >
+    test
+  </div>
+</DocumentFragment>
+`;

--- a/src/__tests__/tailwind.test.tsx
+++ b/src/__tests__/tailwind.test.tsx
@@ -51,4 +51,34 @@ describe('tw', () => {
     const { asFragment } = render(<TestCompStyled>test</TestCompStyled>);
     expect(asFragment()).toMatchSnapshot();
   })
+
+  it("matches snapshot with two properties", () => {
+      const Div = tw.div<{ $test1?: string; $test2?: string }>`
+      bg-gray-500
+      p-10
+      `
+
+      const { asFragment } = render(
+          <Div $test1="true" $test2="true">
+              test
+          </Div>
+      )
+
+      expect(asFragment()).toMatchSnapshot()
+  })
+
+  it("matches snapshot with two dynamic properties", () => {
+      const Div = tw.div<{ $test1?: string; $test2?: string }>`
+      ${(p) => (p.$test1 === "true" ? `bg-gray-500` : ``)}
+      ${(p) => (p.$test2 === "true" ? `p-10` : ``)}
+      `
+
+      const { asFragment } = render(
+          <Div $test1="true" $test2="true">
+              test
+          </Div>
+      )
+
+      expect(asFragment()).toMatchSnapshot()
+  })
 })

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -22,13 +22,9 @@ const cleanTemplate = (template: TemplateStringsArray, inheritedClasses: string 
 
 function parseTailwindClassNames(template: string[], ...templateElements: (string | undefined | null)[]) {
     return template
-        .reduce((sum, n, index) => {
-            const templateElement = templateElements[index]
-            if (typeof templateElement === "string") {
-                return `${sum} ${n} ${templateElement}`
-            }
+        .reduce((sum, n) => {
             return `${sum} ${n}`
-        }, "")
+        }, templateElements.join(' '))
         .trim()
         .replace(/\s{2,}/g, " ") // replace line return by space
 }


### PR DESCRIPTION
**Issue:**
Multiple template literal expressions are not being parse because `parseTailwindClassNames` first parameters' length is not being set to the correct amount.  This fixes that by adding the already evaluated expressions to the reduce function as the default parameter.

Also added additional tests to account for multiple class names, including multiple expressions.