### PR TITLE
Update to ensure Class order is maintained

### DIFF
--- a/src/__tests__/__snapshots__/tailwind.test.tsx.snap
+++ b/src/__tests__/__snapshots__/tailwind.test.tsx.snap
@@ -40,6 +40,16 @@ exports[`tw matches snapshot with two dynamic properties 1`] = `
 </DocumentFragment>
 `;
 
+exports[`tw matches snapshot with two properties & two dynamic properties and maintains class order 1`] = `
+<DocumentFragment>
+  <div
+    class="z-10 bg-gray-500 text-white p-10"
+  >
+    test
+  </div>
+</DocumentFragment>
+`;
+
 exports[`tw matches snapshot with two properties 1`] = `
 <DocumentFragment>
   <div

--- a/src/__tests__/tailwind.test.tsx
+++ b/src/__tests__/tailwind.test.tsx
@@ -1,84 +1,107 @@
-import React, { useEffect, useRef } from 'react'
-import tw from '../tailwind'
-import { act, render } from '@testing-library/react';
+import React, { useEffect, useRef } from "react"
+import tw from "../tailwind"
+import { act, render } from "@testing-library/react"
 
 interface TestCompProps {
-  className?: string
-  someThingElse?: string
-  ref?: unknown
-  children?: React.ReactNode | React.ReactNode[]
+    className?: string
+    someThingElse?: string
+    ref?: unknown
+    children?: React.ReactNode | React.ReactNode[]
 }
 
-describe('tw', () => {
-  it('passes ref [Type Test]', async () => {
-    const Div = tw.div`bg-gray-400`;
-    let r: any = undefined;
-    const HasRef = () => {
-      const ref = useRef<HTMLDivElement>();
-      useEffect(() => {
-        r = ref;
-      }, [ref]);
-      return <Div data-testid="mydiv" ref={ref}>ref</Div>
-    }
-    render(<HasRef />);
-    await act(async () => {
-      expect(r).not.toBeUndefined();
-      expect(r.current).not.toBeUndefined();
-      expect(r.current.localName).toBe('div');
-    });
-  })
+describe("tw", () => {
+    it("passes ref [Type Test]", async () => {
+        const Div = tw.div`bg-gray-400`
+        let r: any = undefined
+        const HasRef = () => {
+            const ref = useRef<HTMLDivElement>()
+            useEffect(() => {
+                r = ref
+            }, [ref])
+            return (
+                <Div data-testid="mydiv" ref={ref}>
+                    ref
+                </Div>
+            )
+        }
+        render(<HasRef />)
+        await act(async () => {
+            expect(r).not.toBeUndefined()
+            expect(r.current).not.toBeUndefined()
+            expect(r.current.localName).toBe("div")
+        })
+    })
 
-  it('matches snapshot with intrinsic element', () => {
-    const Div = tw.div`bg-gray-400`;
-    const { asFragment } = render(<Div>test</Div>);
-    expect(asFragment()).toMatchSnapshot();
-  })
+    it("matches snapshot with intrinsic element", () => {
+        const Div = tw.div`bg-gray-400`
+        const { asFragment } = render(<Div>test</Div>)
+        expect(asFragment()).toMatchSnapshot()
+    })
 
-  it('matches snapshot with function component', () => {
-    const TestComp: React.FC<TestCompProps> = ({ className, children }) => <div className={className}>{children}</div>
-    const TestCompStyled = tw(TestComp)`bg-gray-400`;
-    const { asFragment } = render(<TestCompStyled>test</TestCompStyled>);
-    expect(asFragment()).toMatchSnapshot();
-  })
+    it("matches snapshot with function component", () => {
+        const TestComp: React.FC<TestCompProps> = ({ className, children }) => (
+            <div className={className}>{children}</div>
+        )
+        const TestCompStyled = tw(TestComp)`bg-gray-400`
+        const { asFragment } = render(<TestCompStyled>test</TestCompStyled>)
+        expect(asFragment()).toMatchSnapshot()
+    })
 
-  it('matches snapshot with class component', () => {
-    class TestComp extends React.Component<TestCompProps> {
-      render() {
-        return <div className={this.props.className}>{this.props.children}</div>
-      }
-    }
-    const TestCompStyled = tw(TestComp)`bg-gray-400`;
-    const { asFragment } = render(<TestCompStyled>test</TestCompStyled>);
-    expect(asFragment()).toMatchSnapshot();
-  })
+    it("matches snapshot with class component", () => {
+        class TestComp extends React.Component<TestCompProps> {
+            render() {
+                return <div className={this.props.className}>{this.props.children}</div>
+            }
+        }
+        const TestCompStyled = tw(TestComp)`bg-gray-400`
+        const { asFragment } = render(<TestCompStyled>test</TestCompStyled>)
+        expect(asFragment()).toMatchSnapshot()
+    })
 
-  it("matches snapshot with two properties", () => {
-      const Div = tw.div<{ $test1?: string; $test2?: string }>`
+    it("matches snapshot with two properties", () => {
+        const Div = tw.div<{ $test1?: string; $test2?: string }>`
       bg-gray-500
       p-10
       `
 
-      const { asFragment } = render(
-          <Div $test1="true" $test2="true">
-              test
-          </Div>
-      )
+        const { asFragment } = render(
+            <Div $test1="true" $test2="true">
+                test
+            </Div>
+        )
 
-      expect(asFragment()).toMatchSnapshot()
-  })
+        expect(asFragment()).toMatchSnapshot()
+    })
 
-  it("matches snapshot with two dynamic properties", () => {
-      const Div = tw.div<{ $test1?: string; $test2?: string }>`
+    it("matches snapshot with two dynamic properties", () => {
+        const Div = tw.div<{ $test1?: string; $test2?: string }>`
       ${(p) => (p.$test1 === "true" ? `bg-gray-500` : ``)}
       ${(p) => (p.$test2 === "true" ? `p-10` : ``)}
       `
 
-      const { asFragment } = render(
-          <Div $test1="true" $test2="true">
-              test
-          </Div>
-      )
+        const { asFragment } = render(
+            <Div $test1="true" $test2="true">
+                test
+            </Div>
+        )
 
-      expect(asFragment()).toMatchSnapshot()
-  })
+        expect(asFragment()).toMatchSnapshot()
+    })
+
+    it("matches snapshot with two properties & two dynamic properties and maintains class order", () => {
+        const Div = tw.div<{ $test1?: string; $test2?: string }>`
+      z-10
+      ${(p) => (p.$test1 === "true" ? `bg-gray-500` : ``)}
+      text-white
+      ${(p) => (p.$test2 === "true" ? `p-10` : ``)}
+      `
+
+        const { asFragment } = render(
+            <Div $test1="true" $test2="true">
+                test
+            </Div>
+        )
+
+        expect(asFragment()).toMatchSnapshot()
+    })
 })

--- a/src/__tests__/tailwind.test.tsx
+++ b/src/__tests__/tailwind.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react"
-import tw from "../tailwind"
+import tw, { mergeArrays, cleanTemplate } from "../tailwind"
 import { act, render } from "@testing-library/react"
 
 interface TestCompProps {
@@ -8,6 +8,37 @@ interface TestCompProps {
     ref?: unknown
     children?: React.ReactNode | React.ReactNode[]
 }
+
+describe("mergeArrays", () => {
+    it("should merge arrays of same size in correct order", () => {
+        const arr1 = ["1", "3", "5", "7", "9"]
+        const arr2 = ["2", "4", "6", "8", "10"]
+        const result = mergeArrays(arr1 as unknown as TemplateStringsArray, arr2)
+        expect(result).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"])
+    })
+
+    it("should merge arrays of different size in correct order", () => {
+        const arr1 = ["1", "3", "5", "7", "9"]
+        const arr2 = ["2", "4", "6", "8"]
+        const result = mergeArrays(arr1 as unknown as TemplateStringsArray, arr2)
+        expect(result).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9"])
+    })
+})
+
+describe("cleanTemplate", () => {
+    it("should return a class string", () => {
+        const template = [
+            `fixed
+    h-full
+    w-full
+    bg-green-500
+    `
+        ]
+        const result = cleanTemplate(template)
+
+        expect(result).toEqual("fixed h-full w-full bg-green-500")
+    })
+})
 
 describe("tw", () => {
     it("passes ref [Type Test]", async () => {

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -2,6 +2,13 @@ import React from "react"
 import domElements from "./domElements"
 import { classnames } from "tailwindcss-classnames"
 
+const mergeTemplateStringArrays = (template: TemplateStringsArray, templateElements: (string | undefined | null)[]) => {
+    return template.reduce(
+        (acc, c, i) => acc.concat(c || [], templateElements[i] || []), //  x || [] to remove falsey values
+        [] as (string | undefined | null)[]
+    )
+}
+
 const cleanTemplate = (template: TemplateStringsArray, inheritedClasses: string = "") => {
     const newClasses: string[] = template
         .toString()
@@ -24,7 +31,7 @@ function parseTailwindClassNames(template: string[], ...templateElements: (strin
     return template
         .reduce((classes, c) => {
             return `${classes} ${c}` // set tailwind classes names on one line
-        }, templateElements.join(' '))
+        }, templateElements.join(" "))
         .trim()
         .replace(/\s{2,}/g, " ") // replace line return by space
 }
@@ -44,22 +51,21 @@ function functionTemplate<P extends ClassNameProp, E = any>(Element: React.Compo
     return <K extends {}>(
         template: TemplateStringsArray,
         ...templateElements: ((props: P & K) => string | undefined | null)[]
-    ) =>
-        {
-            return React.forwardRef<E, P & K>((props, ref) => (
-                <Element
-                    // forward props
-                    {...Object.fromEntries(Object.entries(props).filter(([key]) => key.charAt(0) !== "$")) as P} // filter out props that starts with "$"
-
-                    // forward ref
-                    ref={ref}
-                    // set class names
-                    className={parseTailwindClassNames(
-                        cleanTemplate(template, props.className),
-                        ...templateElements.map((t) => t(props))
-                    )} />
-            ))
-        }
+    ) => {
+        return React.forwardRef<E, P & K>((props, ref) => (
+            <Element
+                // forward props
+                {...(Object.fromEntries(Object.entries(props).filter(([key]) => key.charAt(0) !== "$")) as P)} // filter out props that starts with "$"
+                // forward ref
+                ref={ref}
+                // set class names
+                className={parseTailwindClassNames(
+                    cleanTemplate(template, props.className),
+                    ...templateElements.map((t) => t(props))
+                )}
+            />
+        ))
+    }
 }
 
 export type IntrinsicElements = {

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -4,16 +4,16 @@ import { classnames } from "tailwindcss-classnames"
 
 const mergeArrays = (template: TemplateStringsArray, templateElements: (string | undefined | null)[]) => {
     return template.reduce(
-        (acc, c, i) => acc.concat(c || [], templateElements[i] || []), //  x || [] to remove falsey values
+        (acc, c, i) => acc.concat(c || [], templateElements[i] || []), //  x || [] to remove falsey values e.g '', null, undefined
         [] as (string | undefined | null)[]
     )
 }
 
-const cleanTemplate = (template: TemplateStringsArray, inheritedClasses: string = "") => {
+const cleanTemplate = (template: (string | undefined | null)[], inheritedClasses: string = "") => {
     const newClasses: string[] = template
         .toString()
         .trim()
-        .replace(/\s{2,}/g, " ")
+        .replace(/\s{2,}/g, " ") // replace line return by space
         .split(" ")
         .filter((c) => c !== ",") // remove comma introduced by template to string
 
@@ -24,17 +24,17 @@ const cleanTemplate = (template: TemplateStringsArray, inheritedClasses: string 
             .concat(newClasses) // add new classes
             .filter((c: string) => c !== " ") // remove empty classes
             .filter((v: string, i: number, arr: string[]) => arr.indexOf(v) === i) // remove duplicate
-    ).split(" ")
+    )
 }
 
-function parseTailwindClassNames(template: string[], ...templateElements: (string | undefined | null)[]) {
-    return template
-        .reduce((classes, c) => {
-            return `${classes} ${c}` // set tailwind classes names on one line
-        }, templateElements.join(" "))
-        .trim()
-        .replace(/\s{2,}/g, " ") // replace line return by space
-}
+// function parseTailwindClassNames(template: string[], ...templateElements: (string | undefined | null)[]) {
+//     return template
+//         .reduce((classes, c) => {
+//             return `${classes} ${c}` // set tailwind classes names on one line
+//         }, templateElements.join(" "))
+//         .trim()
+//         .replace(/\s{2,}/g, " ") // replace line return by space
+// }
 
 type TransientProps = Record<`$${string}`, any>
 
@@ -59,9 +59,12 @@ function functionTemplate<P extends ClassNameProp, E = any>(Element: React.Compo
                 // forward ref
                 ref={ref}
                 // set class names
-                className={parseTailwindClassNames(
-                    cleanTemplate(template, props.className),
-                    ...templateElements.map((t) => t(props))
+                className={cleanTemplate(
+                    mergeArrays(
+                        template,
+                        templateElements.map((t) => t(props))
+                    ),
+                    props.className
                 )}
             />
         ))

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -13,7 +13,7 @@ export const cleanTemplate = (template: (string | undefined | null)[], inherited
     const newClasses: string[] = template
         .join(" ")
         .trim()
-        // .replace(/\n/g, ' ')     // replace newline with space
+        .replace(/\n/g, ' ')     // replace newline with space
         .replace(/\s{2,}/g, " ") // replace line return by space
         .split(" ")
         .filter((c) => c !== ",") // remove comma introduced by template to string

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -11,7 +11,7 @@ const mergeArrays = (template: TemplateStringsArray, templateElements: (string |
 
 const cleanTemplate = (template: (string | undefined | null)[], inheritedClasses: string = "") => {
     const newClasses: string[] = template
-        .toString()
+        .join(" ")
         .trim()
         .replace(/\s{2,}/g, " ") // replace line return by space
         .split(" ")

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -2,17 +2,18 @@ import React from "react"
 import domElements from "./domElements"
 import { classnames } from "tailwindcss-classnames"
 
-const mergeArrays = (template: TemplateStringsArray, templateElements: (string | undefined | null)[]) => {
+export const mergeArrays = (template: TemplateStringsArray, templateElements: (string | undefined | null)[]) => {
     return template.reduce(
-        (acc, c, i) => acc.concat(c || [], templateElements[i] || []), //  x || [] to remove falsey values e.g '', null, undefined
+        (acc, c, i) => acc.concat(c || [], templateElements[i] || []), //  x || [] to remove falsey values e.g '', null, undefined. as Array.concat() ignores empty arrays i.e []
         [] as (string | undefined | null)[]
     )
 }
 
-const cleanTemplate = (template: (string | undefined | null)[], inheritedClasses: string = "") => {
+export const cleanTemplate = (template: (string | undefined | null)[], inheritedClasses: string = "") => {
     const newClasses: string[] = template
         .join(" ")
         .trim()
+        // .replace(/\n/g, ' ')     // replace newline with space
         .replace(/\s{2,}/g, " ") // replace line return by space
         .split(" ")
         .filter((c) => c !== ",") // remove comma introduced by template to string
@@ -24,7 +25,7 @@ const cleanTemplate = (template: (string | undefined | null)[], inheritedClasses
             .concat(newClasses) // add new classes
             .filter((c: string) => c !== " ") // remove empty classes
             .filter((v: string, i: number, arr: string[]) => arr.indexOf(v) === i) // remove duplicate
-    )
+    ) as string // to remove "TAILWIND_STRING" type
 }
 
 // function parseTailwindClassNames(template: string[], ...templateElements: (string | undefined | null)[]) {

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import domElements from "./domElements"
 import { classnames } from "tailwindcss-classnames"
 
-const mergeTemplateStringArrays = (template: TemplateStringsArray, templateElements: (string | undefined | null)[]) => {
+const mergeArrays = (template: TemplateStringsArray, templateElements: (string | undefined | null)[]) => {
     return template.reduce(
         (acc, c, i) => acc.concat(c || [], templateElements[i] || []), //  x || [] to remove falsey values
         [] as (string | undefined | null)[]


### PR DESCRIPTION
The default implementation was changing the order in which classes were added to the dom element as opposed to the order written in code.

All dynamic properties were shifted to the front of the class list, this meant that cases where the order is important could in theory lead to hard to debug issues.

eg.

    const Div = tw.div`
        hidden
       ${ p => p.show ? 'block' : ''}
    `
when `p.show` is true, would render 
`<div class="block hidden"><div/>`
instead of
`<div class="hidden block"><div/>`

While this isn't really an issue due to the atomic nature of tailwind because the class definition order in the css file would take priority over the class order. It's best to deal with it.

This PR ensures class order is maintained by merging `templates`  and `templateElements` arrays alternatively to maintain the order.

Also merging the two arrays makes `parseTailwindClassNames` redundant as cleanTemplate does all the necessary parsing on the single array.

I also added tests to ensure class order is maintained and individual tests for internal utility functions.

NOTE: I also fixed an issue where newline characters were not removed i.e "\n" by adding `.replace(/\n/g, '  ')` to cleanTemplate, this previously messed up the devtools view by making classes multiline.