### PR TITLE
Change package.json to require react as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,16 @@
         "eslint-plugin-prettier": "^3.1.4",
         "jest": "^26.6.3",
         "prettier": "^2.5.1",
+        "react": "^17.0.1",
         "react-dom": "^17.0.2",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.5",
         "typescript": "^4.2.4"
     },
+    "peerDependencies": {
+        "react": "^17.0.1"
+    },
     "dependencies": {
-        "react": "^17.0.1",
         "tailwindcss-classnames": "^2.1.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3523,9 +3523,9 @@ react-is@^17.0.1:
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Thanks for this great project! I'm excited to use tailwindcss but I didn't want to give up my precious styled components.

In my mind it is clear that react should be a peer dependency of your project. If this project depends on react, then when it is required by another project that depends on react, there is a risk of two different versions of react existing on the same page (which is something react can't handle). On the other hand, if this project declares react as a dev dependency, and as a peer dependency, then when it is used alongside another project that project will need to install react.

For example: I'm using tailwind-styled-components to develop a component library. The component library will be required by other apps that declare react as a dependency. If my component library or any of its dependencies declare react or react-dom as a dependency, then there will be a conflict when running the app.

What do you think?

