### PR TITLE
Fix: `TS2590: Expression produces a union type that is too complex to represent.` bug, 

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,7 +17,7 @@ export default () => {
                 Hello
             </Title>
             <Title $bold={false} $large={false} $as={RedContainer}>
-                Hello, I'm a Title rendered as a RedContainer
+                Hello, I'm a Title rendered as a RedContainer, Polymorphism!
             </Title>
             <Input onChange={onChange} onFocus={() => console.log(`focus`)} value={value} />
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -52,6 +52,7 @@ const Anchor = styled(TwAnchor)<{ $active?: boolean }>`
     color: ${(props) => (props.$active ? "red" : "blue")};
 `
 
+
 const Input = tw.input``
 
 const Container = tw.div`
@@ -63,6 +64,10 @@ const DefaultContainer = tw.div<{ $bold?: boolean }>`
 
     flex
     items-center
+`
+
+const StyledContainer = styled(DefaultContainer)<{ $active?: boolean }>`
+    color: ${(props) => (props.$active ? "red" : "blue")};
 `
 
 const RedContainer = tw(DefaultContainer)`

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "dev": "tsc -w",
         "clean": "rimraf dist",
         "test": "jest",
-        "posttest": "tsc -p ./src/typing-tests/tsconfig.json",
+        "test:types": "tsc -p ./src/typing-tests/tsconfig.json",
+        "posttest": "yarn run test:types",
         "prepublishOnly": "npm run clean && npm run build"
     },
     "homepage": "https://github.com/MathiasGilson/tailwind-styled-component",

--- a/src/__tests__/__snapshots__/tailwind.test.tsx.snap
+++ b/src/__tests__/__snapshots__/tailwind.test.tsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`tw $as props polymorphism should work with class component 1`] = `
+<DocumentFragment>
+  <a
+    class="bg-gray-400"
+    href="http://###"
+  >
+    test
+  </a>
+</DocumentFragment>
+`;
+
 exports[`tw matches snapshot with class component 1`] = `
 <DocumentFragment>
   <div
@@ -69,6 +80,14 @@ exports[`tw should render Component as html tag in \`$as\` prop 1`] = `
 </DocumentFragment>
 `;
 
+exports[`tw should render base class component as component in \`$as\` prop: test 1 1`] = `
+<DocumentFragment>
+  <nav
+    class="flex h-20 w-full flex-col h-full w-20 text-black bg-gray-500"
+  />
+</DocumentFragment>
+`;
+
 exports[`tw should render component as component in \`$as\` prop: test 1 1`] = `
 <DocumentFragment>
   <nav
@@ -81,16 +100,6 @@ exports[`tw should render component as component in \`$as\` prop: test 2 1`] = `
 <DocumentFragment>
   <nav
     class="flex h-20 w-full bg-red-500"
-  />
-</DocumentFragment>
-`;
-
-
-exports[`tw should render tag Component as html tag in \`$as\` prop 1`] = `
-<DocumentFragment>
-  <a
-    class="text-black bg-gray-500"
-    href="http://"
   />
 </DocumentFragment>
 `;

--- a/src/__tests__/tailwind.test.tsx
+++ b/src/__tests__/tailwind.test.tsx
@@ -163,6 +163,21 @@ describe("tw", () => {
         expect(asFragment()).toMatchSnapshot()
     })
 
+    it("$as props polymorphism should work with class component", () => {
+        class TestComp extends React.Component<TestCompProps> {
+            render() {
+                return <div className={this.props.className}>{this.props.children}</div>
+            }
+        }
+        const TestCompStyled = tw(TestComp)`bg-gray-400`
+        const { asFragment } = render(
+            <TestCompStyled $as="a" href="http://###">
+                test
+            </TestCompStyled>
+        )
+        expect(asFragment()).toMatchSnapshot()
+    })
+
     it("should render Component as html tag in `$as` prop", () => {
         const Div = tw.div<{ $test1: string }>`
         text-black
@@ -181,6 +196,21 @@ describe("tw", () => {
         const Nav = tw.nav<{ $isVertical: boolean }>`flex h-20 w-full ${(p) =>
             p.$isVertical === true ? "flex-col h-full w-20" : ""}`
         const { asFragment } = render(<Div $as={Nav} $test1="true" $isVertical={true} />)
+        expect(asFragment()).toMatchSnapshot()
+    })
+    it("should render base class component as component in `$as` prop: test 1", () => {
+        class TestComp extends React.Component<TestCompProps> {
+            render() {
+                return <div className={this.props.className}>{this.props.children}</div>
+            }
+        }
+        const ClassDiv = tw(TestComp)<{ $test1: string }>`
+        text-black
+        ${(p) => (p.$test1 === "true" ? `bg-gray-500` : ``)}
+        `
+        const Nav = tw.nav<{ $isVertical: boolean }>`flex h-20 w-full ${(p) =>
+            p.$isVertical === true ? "flex-col h-full w-20" : ""}`
+        const { asFragment } = render(<ClassDiv $as={Nav} $test1="true" $isVertical={true} />)
         expect(asFragment()).toMatchSnapshot()
     })
 

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -38,10 +38,10 @@ type StripCallSignature<T> = { [K in keyof T]: T[K] }
 // needed for some reason, without it polymorphic $as props typing has issues - help requested
 type SpreadUnion<U> = U extends any ? { [K in keyof U]: U[K] } : never
 
-type TailwindComponentProps<E extends React.ComponentType<any> | IntrinsicElementsKeys, K extends object> = SpreadUnion<
-    React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined>
-> &
-    K
+export type TailwindComponentProps<
+    E extends React.ComponentType<any> | IntrinsicElementsKeys,
+    K extends object
+> = SpreadUnion<React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined>> & K
 
 type TailwindComponentPropsWith$As<
     E extends React.ComponentType<any> | IntrinsicElementsKeys,
@@ -55,7 +55,7 @@ type TailwindExoticComponent<
     // call signatures in React.ForwardRefExoticComponent were interfering
 > = StripCallSignature<React.ForwardRefExoticComponent<TailwindComponentProps<E, K>>>
 
-interface TailwindComponent<E extends React.ComponentType<any> | IntrinsicElementsKeys, K extends object>
+export interface TailwindComponent<E extends React.ComponentType<any> | IntrinsicElementsKeys, K extends object>
     extends TailwindExoticComponent<E, K> {
     (props: TailwindComponentProps<E, K> & { as?: never | undefined }): React.ReactElement<
         TailwindComponentProps<E, K>
@@ -107,7 +107,7 @@ type InnerTailwindComponentAllProps<
     ? React.ComponentPropsWithoutRef<E2> & K2 & React.RefAttributes<React.ComponentRef<E2> | undefined> // | undefined to fix types errors with useRef
     : React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined> // | undefined to fix types errors with useRef
 
-interface TemplateFunctionFactory {
+export interface TemplateFunctionFactory {
     /* overload needed to minimize `union is too complex` errors
 when testing due to the size of the `IntrinsicElementsKeys` union */
     <E extends TailwindComponent<E2, K2>, E2 extends IntrinsicElementsKeys, K2 extends object = {}>(

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -36,20 +36,24 @@ export const cleanTemplate = (template: (string | undefined | null)[], inherited
 type StripCallSignature<T> = { [K in keyof T]: T[K] }
 
 // needed for some reason, without it polymorphic $as props typing has issues - help requested
-type SpreadUnion<U> = U extends any ? { [K in keyof U]: U[K] } : never
+// type SpreadUnion<U> = U extends any ? { [K in keyof U]: U[K] } : never
 
 export type TailwindComponentProps<
     E extends React.ComponentType<any> | IntrinsicElementsKeys,
     K extends object
-> = SpreadUnion<React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined>> & K
+
+    // `X extends any ?` needed to spread union types and minimise complex union errors from exponential spreading
+> = K extends any
+    ? React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined> & K
+    : never
 
 type TailwindComponentPropsWith$As<
     E extends React.ComponentType<any> | IntrinsicElementsKeys,
     K extends object,
     As extends IntrinsicElementsKeys | React.ComponentType<any> = E
-> = SpreadUnion<React.ComponentPropsWithoutRef<E> & InnerTailwindComponentAllProps<As>> & K & { $as?: As }
+> = TailwindComponentProps<E, K> & InnerTailwindComponentAllProps<As> & { $as?: As }
 
-type TailwindExoticComponent<
+export type TailwindExoticComponent<
     E extends React.ComponentType<any> | IntrinsicElementsKeys,
     K extends object
     // call signatures in React.ForwardRefExoticComponent were interfering

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -32,19 +32,32 @@ export const cleanTemplate = (template: (string | undefined | null)[], inherited
     ) as string // to remove "TAILWIND_STRING" type
 }
 
-// Removes call signatures (i.e functions) from Object types
+/** Removes call signatures (i.e functions) from Object types */
 type StripCallSignature<T> = { [K in keyof T]: T[K] }
 
 // needed for some reason, without it polymorphic $as props typing has issues - help requested
 // type SpreadUnion<U> = U extends any ? { [K in keyof U]: U[K] } : never
 
+/**
+ * @author 'DefinitelyTyped/types/styled-components'.
+ *
+ * Because of React typing quirks, when getting props from a React.ComponentClass,
+ * we need to manually add a `children` field.
+ * See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31945
+ * and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32843 */
+// type WithChildrenIfReactComponentClass<C extends string | React.ComponentType<any>> =
+//     C extends React.ComponentClass<any> ? { children?: React.ReactNode | undefined } : {}
+
 export type TailwindComponentProps<
     E extends React.ComponentType<any> | IntrinsicElementsKeys,
     K extends object
 
-    // `X extends any ?` needed to spread union types and minimise complex union errors from exponential spreading
+    /**  `X extends any ?` needed to distribute union types and minimise complex union errors from exponential spreading */
 > = K extends any
-    ? React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined> & K
+    ? React.ComponentPropsWithoutRef<E> &
+          React.RefAttributes<React.ComponentRef<E> | undefined> &
+          //   WithChildrenIfReactComponentClass<E> &
+          K
     : never
 
 type TailwindComponentPropsWith$As<
@@ -56,12 +69,21 @@ type TailwindComponentPropsWith$As<
 export type TailwindExoticComponent<
     E extends React.ComponentType<any> | IntrinsicElementsKeys,
     K extends object
-    // call signatures in React.ForwardRefExoticComponent were interfering
+    /** call signatures in React.ForwardRefExoticComponent were interfering */
 > = StripCallSignature<React.ForwardRefExoticComponent<TailwindComponentProps<E, K>>>
 
+/**
+ * An interface represent a component styled by tailwind-styled-components
+ *
+ * @export
+ * @interface TailwindComponent
+ * @extends {TailwindExoticComponent<E, K>}
+ * @template E The base react component or html tag
+ * @template K The props added with the template function.
+ */
 export interface TailwindComponent<E extends React.ComponentType<any> | IntrinsicElementsKeys, K extends object>
     extends TailwindExoticComponent<E, K> {
-    (props: TailwindComponentProps<E, K> & { as?: never | undefined }): React.ReactElement<
+    (props: TailwindComponentProps<E, K> & { $as?: never | undefined }): React.ReactElement<
         TailwindComponentProps<E, K>
     > | null
 
@@ -69,19 +91,27 @@ export interface TailwindComponent<E extends React.ComponentType<any> | Intrinsi
         props: TailwindComponentPropsWith$As<E, K, As>
     ): React.ReactElement<TailwindComponentPropsWith$As<E, K, As>> | null
 
-    // for easier type narrowing of TailwindComponent
+    /**  for easier type narrowing of TailwindComponent */
     [isTwElement]: boolean
 }
 
-// Avoid unneccessary type inference
+/**  Avoid unneccessary type inference */
 type NoInfer<T> = [T][T extends any ? 0 : never]
 
-export type TemplateFunction<E extends React.ComponentType<any> | IntrinsicElementsKeys, K2 extends object = {}> = <
-    K extends object = {}
->(
-    template: TemplateStringsArray,
-    ...templateElements: ((props: NoInfer<React.ComponentPropsWithRef<E> & K2> & K) => string | undefined | null)[]
-) => TailwindComponent<E, K & K2>
+/**
+ * A template function that accepts a template literal of tailwind classes and returns a tailwind-styled-component
+ *
+ * @export
+ * @interface TemplateFunction
+ * @template E
+ * @template K2
+ */
+export interface TemplateFunction<E extends React.ComponentType<any> | IntrinsicElementsKeys, K2 extends object = {}> {
+    <K extends object = {}>(
+        template: TemplateStringsArray,
+        ...templateElements: ((props: NoInfer<React.ComponentPropsWithRef<E> & K2> & K) => string | undefined | null)[]
+    ): TailwindComponent<E, K & K2>
+}
 
 interface ClassNameProp {
     className?: string | undefined
@@ -93,27 +123,42 @@ interface AsProp {
 // simple type alias
 type BaseProps = AsProp & ClassNameProp
 
+/**
+ * A utility function that strips out transient props from a [key,value] array of props
+ *
+ * @param {[string, any]} [key]
+ * @return boolean
+ */
 const removeTransientProps = ([key]: [string, any]): boolean => key.charAt(0) !== "$"
 
-// Extracts inner tailwind component, e.g it extracts `"div"` from `TailwindComponent<"div", {$test1: string}>`
+/** Extracts inner tailwind component,
+ * e.g it extracts `"div"` from `TailwindComponent<"div", {$test1: string}>` */
 type InnerTailwindComponent<E extends React.ComponentType<any> | IntrinsicElementsKeys | TailwindComponent<any, any>> =
     E extends TailwindComponent<infer E2, any> ? E2 : E
 
-// Extracts inner tailwind component other props, e.g it extracts `{$test1: string}` from `TailwindComponent<"div", {$test1: string}>`
+/**Extracts inner tailwind component other props,
+ * e.g it extracts `{$test1: string}` from `TailwindComponent<"div", {$test1: string}>` */
 type InnerTailwindComponentOtherProps<
     E extends React.ComponentType<any> | IntrinsicElementsKeys | TailwindComponent<any, any>
 > = E extends TailwindComponent<any, infer K2> ? K2 : {}
 
-// Extracts all inner tailwind component props, e.g it returns `React.ComponentProps<"div"> & {$test1: string}` from `TailwindComponent<"div", {$test1: string}>`
+/**Extracts all inner tailwind component props,
+ * e.g it returns `React.ComponentProps<"div"> & {$test1: string}` from `TailwindComponent<"div", {$test1: string}>`*/
 type InnerTailwindComponentAllProps<
     E extends React.ComponentType<any> | IntrinsicElementsKeys | TailwindComponent<any, any>
 > = E extends TailwindComponent<infer E2, infer K2>
     ? React.ComponentPropsWithoutRef<E2> & K2 & React.RefAttributes<React.ComponentRef<E2> | undefined> // | undefined to fix types errors with useRef
     : React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined> // | undefined to fix types errors with useRef
 
+/**
+ * A factory functions that returns templateFunctions
+ *
+ * @export
+ * @interface TemplateFunctionFactory
+ */
 export interface TemplateFunctionFactory {
-    /* overload needed to minimize `union is too complex` errors
-when testing due to the size of the `IntrinsicElementsKeys` union */
+    /** overload needed to minimize `union is too complex` errors
+     * when testing due to the size of the `IntrinsicElementsKeys` union */
     <E extends TailwindComponent<E2, K2>, E2 extends IntrinsicElementsKeys, K2 extends object = {}>(
         Element: E
     ): TemplateFunction<E2, K2>

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -107,24 +107,28 @@ type InnerTailwindComponentAllProps<
     ? React.ComponentPropsWithoutRef<E2> & K2 & React.RefAttributes<React.ComponentRef<E2> | undefined> // | undefined to fix types errors with useRef
     : React.ComponentPropsWithoutRef<E> & React.RefAttributes<React.ComponentRef<E> | undefined> // | undefined to fix types errors with useRef
 
-/* overload needed to minimize `union is too complex` errors
-when testing due to the size of the IntrinsicElementsKeys union */
-function templateFunction<
-    E extends TailwindComponent<E2, K2>,
-    E2 extends IntrinsicElementsKeys,
-    K2 extends object = {}
->(Element: E): TemplateFunction<E2, K2>
+interface TemplateFunctionFactory {
+    /* overload needed to minimize `union is too complex` errors
+when testing due to the size of the `IntrinsicElementsKeys` union */
+    <E extends TailwindComponent<E2, K2>, E2 extends IntrinsicElementsKeys, K2 extends object = {}>(
+        Element: E
+    ): TemplateFunction<E2, K2>
 
-function templateFunction<E extends TailwindComponent<any, any>>(
+    <E extends TailwindComponent<any, any>>(Element: E): TemplateFunction<
+        InnerTailwindComponent<E>,
+        InnerTailwindComponentOtherProps<E>
+    >
+
+    <E extends IntrinsicElementsKeys>(Element: E): TemplateFunction<E>
+
+    <E extends React.ComponentType<any>>(Element: E): TemplateFunction<E>
+}
+
+const templateFunction: TemplateFunctionFactory = <
+    E extends React.ComponentType<any> | IntrinsicElementsKeys | TailwindComponent<any, any>
+>(
     Element: E
-): TemplateFunction<InnerTailwindComponent<E>, InnerTailwindComponentOtherProps<E>>
-
-function templateFunction<E extends IntrinsicElementsKeys>(Element: E): TemplateFunction<E>
-function templateFunction<E extends React.ComponentType<any>>(Element: E): TemplateFunction<E>
-
-function templateFunction<E extends React.ComponentType<any> | IntrinsicElementsKeys | TailwindComponent<any, any>>(
-    Element: E
-): TemplateFunction<InnerTailwindComponent<E>, InnerTailwindComponentOtherProps<E>> {
+): TemplateFunction<InnerTailwindComponent<E>, InnerTailwindComponentOtherProps<E>> => {
     return <K extends object = {}>(
         template: TemplateStringsArray,
         ...templateElements: ((props: InnerTailwindComponentAllProps<E> & K) => string | undefined | null)[]

--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -124,7 +124,7 @@ when testing due to the size of the `IntrinsicElementsKeys` union */
     <E extends React.ComponentType<any>>(Element: E): TemplateFunction<E>
 }
 
-const templateFunction: TemplateFunctionFactory = <
+const templateFunctionFactory: TemplateFunctionFactory = <
     E extends React.ComponentType<any> | IntrinsicElementsKeys | TailwindComponent<any, any>
 >(
     Element: E
@@ -176,18 +176,18 @@ const templateFunction: TemplateFunctionFactory = <
     }
 }
 
-export type IntrinsicElements = {
+export type IntrinsicElementsTemplateFunctionsMap = {
     [key in IntrinsicElementsKeys]: TemplateFunction<key>
 }
 
-const intrinsicElements: IntrinsicElements = domElements.reduce(
-    <K extends IntrinsicElementsKeys>(acc: IntrinsicElements, DomElement: K) => ({
+const intrinsicElementsMap: IntrinsicElementsTemplateFunctionsMap = domElements.reduce(
+    <K extends IntrinsicElementsKeys>(acc: IntrinsicElementsTemplateFunctionsMap, DomElement: K) => ({
         ...acc,
-        [DomElement]: templateFunction(DomElement)
+        [DomElement]: templateFunctionFactory(DomElement)
     }),
-    {} as IntrinsicElements
+    {} as IntrinsicElementsTemplateFunctionsMap
 )
 
-const tw = Object.assign(templateFunction, intrinsicElements)
+const tw = Object.assign(templateFunctionFactory, intrinsicElementsMap)
 
 export default tw

--- a/src/typing-tests/tailwind.typing.tsx
+++ b/src/typing-tests/tailwind.typing.tsx
@@ -12,32 +12,41 @@ const Div = tw.div``
 const H1 = tw.h1``
 const A = tw.a``
 
-// @ts-expect-error
-const dfsdfe = <Div href="/" />
+/**Test: Properly gives a type error when wrong props are used */
+{
+    // @ts-expect-error
+    const Test1 = <Div href="/" />
+    // @ts-expect-error
+    const Test2 = Div({ href: "/" })
+}
 
-const dfsdfe2 = <Div $as="a" href="/" />
-// @ts-expect-error
-const dfsdfe2b = <Div $as="div" href="/" />
-// @ts-expect-error
-const dfsdfe3 = <Div $as={Div} href="/" />
-// @ts-expect-error
-const dfsdfe3b2 = Div({ $as: "div", href: "/" })
-// @ts-expect-error
-const dfsdfe3b2n = Div({ href: "/" })
-// @ts-expect-error
-const dfsdfe3a = <Div $as={H1} href="/" />
-const dfsdfe3b = <Div $as="a" href="/" />
+/**Test: props are type cast properly with $as prop */
+{
+    const Test1 = <Div $as="a" href="/" />
+    const Test2 = <Div $as={A} href="/" />
+}
 
-const dfsdfe3c = <Div $as={A} href="/" />
+/** Test: types error for wrong props with $as prop */
+{
+    // @ts-expect-error
+    const dfsdfe2b = <Div $as="div" href="/" />
+    // @ts-expect-error
+    const dfsdfe3 = <Div $as={Div} href="/" />
+    // @ts-expect-error
+    const dfsdfe3b2 = Div({ $as: "div", href: "/" })
+    // @ts-expect-error
+    const dfsdfe3a = <Div $as={H1} href="/" />
+}
 
-const C1 = (props: { className: string; booleanProp?: boolean }) => <div children={props.booleanProp} />
-const C2 = () => <div />
+/** Has className prop and optional booleanProp */
+const Component1 = (props: { className: string; booleanProp?: boolean }) => <div children={props.booleanProp} />
+const Component2 = () => <div />
 const C3 = (props: { booleanProp: boolean }) => <div children={props.booleanProp} />
 const C4 = (props: { booleanProp: boolean; children?: string }) => <div children={props.booleanProp} />
 const C5 = (props: React.PropsWithChildren<{ booleanProp: boolean }>) => <div children={props.booleanProp} />
 
 const T = tw.div``
-const HasClassName = tw(C1)``
+const HasClassName = tw(Component1)``
 const HasClassNameAndBoolean = tw(C3)`
 h-full
 `
@@ -56,7 +65,7 @@ expectType<{ booleanProp: boolean } & { children: React.ReactNode }>(result)
 
 // type P =
 
-const NoProps = tw(C2)``
+const NoProps = tw(Component2)``
 
 const TG = (props: { gar: number }) => <div>{props.gar}</div>
 
@@ -108,11 +117,11 @@ type TTTTT = React.ComponentPropsWithRef<typeof HasClassName>
 
 const sfdkj3 = (
     <T
-        $as={C1}
+        $as={Component1}
         className=""
         booleanProp={true}
         // onChange= () => {}}
     />
 )
 // @ts-expect-error
-const sfd4 = <T $as={C1} className="" css="true" />
+const sfd4 = <T $as={Component1} className="" css="true" />

--- a/src/typing-tests/tailwind.typing.tsx
+++ b/src/typing-tests/tailwind.typing.tsx
@@ -62,10 +62,10 @@ const TG = (props: { gar: number }) => <div>{props.gar}</div>
 
 const TR = tw(TG)``
 
-// const Divvy = tw.div<{ $test1: string }>`
-//         text-black
-//         `
-// const RedDiv = tw(Divvy)`bg-red-500`
+const Divvy = tw.div<{ $test1: string }>`
+        text-black
+        `
+const RedDiv2 = tw(Divvy)`bg-red-500`
 
 const AsDiv = <RedDiv $as="div" $test1="true" />
 // @ts-expect-error

--- a/src/typing-tests/tailwind.typing.tsx
+++ b/src/typing-tests/tailwind.typing.tsx
@@ -3,6 +3,11 @@ import tw from "../tailwind"
 import React from "react"
 import { expectExactAny, expectExactType, expectNotAny, expectType } from "./test-types"
 
+const Divvy2 = tw("div")<{ $test1: string }>`
+        text-black
+        `
+const RedDiv = tw(Divvy2)`bg-red-500`
+
 const Div = tw.div``
 const H1 = tw.h1``
 const A = tw.a``
@@ -57,10 +62,10 @@ const TG = (props: { gar: number }) => <div>{props.gar}</div>
 
 const TR = tw(TG)``
 
-const Divvy = tw.div<{ $test1: string }>`
-        text-black
-        `
-const RedDiv = tw(Divvy)`bg-red-500`
+// const Divvy = tw.div<{ $test1: string }>`
+//         text-black
+//         `
+// const RedDiv = tw(Divvy)`bg-red-500`
 
 const AsDiv = <RedDiv $as="div" $test1="true" />
 // @ts-expect-error


### PR DESCRIPTION
This PR fixes the issue of `TS2590: Expression produces a union type that is too complex to represent.` bug encountered in PR #40 

It does this by changing the structure of the types and adding `X extends any ? DoSomething<X> : never` at certain points to distribute unions and avoid quadratic expansion of large unions. i.e instead of 138^n types we get 138*n types.

Fix was taken from how styled-components handled the same issue so this should work well.

Other minor changes: 

- Added some test to ensure class components work fine with `$as` prop
- Added JsDoc comments for better documentation
- fixed typo in types (put `as` instead of `$as`)
- Ongoing: organise typing-tests in a sensible manner 