### PR TITLE
fix for typescript error on strict builds

### DIFF
--- a/src/tailwind.tsx
+++ b/src/tailwind.tsx
@@ -64,7 +64,7 @@ type MergeProps<O extends object, P extends {} = {}> =
 // RemoveIndex<P> is used to make React.ComponentPropsWithRef typesafe on Tailwind components, delete if causing issues
 
 type TailwindPropHelper<
-    P,
+    P extends object = {},
     O extends object = {}
     // PickU is needed here to make $as typing work
 > = PickU<MergeProps<O, P>, keyof MergeProps<O, P>>
@@ -73,7 +73,7 @@ type TailwindComponentPropsWith$As<
     P extends object,
     O extends object,
     $As extends string | React.ComponentType<any> = React.ComponentType<P>,
-    P2 = $As extends AnyTailwindComponent
+    P2 extends object = $As extends AnyTailwindComponent
         ? TailwindComponentAllInnerProps<$As>
         : $As extends IntrinsicElementsKeys | React.ComponentType<any>
         ? React.ComponentPropsWithRef<$As>


### PR DESCRIPTION
Hello!

I was using `tailwind-styled-components` in another project, and when I ran my build, it was getting caught on a Typescript error coming from this package:

```
> tsc && vite build

node_modules/tailwind-styled-components/dist/tailwind.d.ts:27:81 - error TS2344: Type 'P' does not satisfy the constraint '{}'.

27 declare type TailwindPropHelper<P, O extends object = {}> = PickU<MergeProps<O, P>, keyof MergeProps<O, P>>;
                                                                                   ~

  node_modules/tailwind-styled-components/dist/tailwind.d.ts:27:33
    27 declare type TailwindPropHelper<P, O extends object = {}> = PickU<MergeProps<O, P>, keyof MergeProps<O, P>>;
                                       ~
    This type parameter might need an `extends {}` constraint.

node_modules/tailwind-styled-components/dist/tailwind.d.ts:27:105 - error TS2344: Type 'P' does not satisfy the constraint '{}'.

27 declare type TailwindPropHelper<P, O extends object = {}> = PickU<MergeProps<O, P>, keyof MergeProps<O, P>>;
                                                                                                           ~

  node_modules/tailwind-styled-components/dist/tailwind.d.ts:27:33
    27 declare type TailwindPropHelper<P, O extends object = {}> = PickU<MergeProps<O, P>, keyof MergeProps<O, P>>;
                                       ~
    This type parameter might need an `extends {}` constraint.


Found 2 errors in the same file, starting at: node_modules/tailwind-styled-components/dist/tailwind.d.ts:27
```

So I figured I would submit a fix, based on Typescript's suggestion.
This extends `object` for an input type in 2 places, similarly to adjacent input types.

All tests pass, and the package builds. Happy to respond to any questions!
Let me know if/when this can be bundled into the next version, as I'll be maintaining a fork for my project until then.

Thank you!
